### PR TITLE
Add timezone to internal log events' timestamp (potential fix for issue #80)

### DIFF
--- a/src/bin/lookup_backups_rest_handler.py
+++ b/src/bin/lookup_backups_rest_handler.py
@@ -27,7 +27,7 @@ def setup_logger(level):
     file_handler = logging.handlers.RotatingFileHandler(log_file_path, maxBytes=25000000,
                                                         backupCount=5)
 
-    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p %z')
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     return logger

--- a/src/bin/lookup_editor_rest_handler.py
+++ b/src/bin/lookup_editor_rest_handler.py
@@ -30,7 +30,7 @@ def setup_logger(level):
     file_handler = logging.handlers.RotatingFileHandler(log_file_path, maxBytes=25000000,
                                                         backupCount=5)
 
-    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p %z')
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     return logger


### PR DESCRIPTION
Potential fix for issue #80 
Add timezone to internal log events' timestamp, so Splunk should know the local user timezone (who triggered the log event) and visualize it accordingly, not assuming it was created in system/local user TZ.